### PR TITLE
Fix production build script for wasmJs target

### DIFF
--- a/shared/src/commonMain/kotlin/component/WorkCard.kt
+++ b/shared/src/commonMain/kotlin/component/WorkCard.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Tag
 import androidx.compose.material3.*
+import androidx.compose.material3.TooltipAnchorPosition
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -103,7 +104,9 @@ internal fun LinkButton(
     icon: ImageVector,
     contentDescription: String,
 ) = TooltipBox(
-    positionProvider = TooltipDefaults.rememberTooltipPositionProvider(),
+    positionProvider = TooltipDefaults.rememberTooltipPositionProvider(
+        TooltipAnchorPosition.Above,
+    ),
     state = rememberTooltipState(),
     tooltip = { PlainTooltip { Text(label) } },
 ) {

--- a/web/build.gradle.kts
+++ b/web/build.gradle.kts
@@ -42,7 +42,7 @@ val copyDistributions by tasks.registering {
                 destinationDir.mkdir()
             }
             val distributions =
-                File("${layout.buildDirectory.asFile.get().absoluteFile}/dist/js/productionExecutable/")
+                File("${layout.buildDirectory.asFile.get().absoluteFile}/dist/wasmJs/productionExecutable/")
             from(distributions)
             into(destinationDir)
         }


### PR DESCRIPTION
## Summary
- Fix distribution path in build script from `js` to `wasmJs`
- Add explicit tooltip anchor position configuration

## Test plan
- [x] Verify production build generates files in correct wasmJs directory
- [x] Verify tooltip displays above the button correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)